### PR TITLE
[fix] Mail 포트 587(TLS)에서 포트 465(SSL) 방식으로 변경

### DIFF
--- a/BE/src/main/resources/application.properties
+++ b/BE/src/main/resources/application.properties
@@ -18,11 +18,11 @@ spring.data.redis.timeout=${REDIS_TIMEOUT}
 
 # Mail
 spring.mail.host=smtp.gmail.com
-spring.mail.port=587
+spring.mail.port=465
 spring.mail.username=${MAIL_USERNAME}
 spring.mail.password=${MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
-spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.ssl.enable=true
 
 # registration
 spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID}


### PR DESCRIPTION
## 📝 변경 사항
- application.properties에서 Mail 전송을 SSL 방식으로 변경

## ✅ PR 체크리스트

- [ ] 관련 문서 업데이트 (필요한 경우)

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/8d6d7af3-fc31-4ac5-b42b-ac4c966f2047)

## 📌 참고 사항

- 이 변경 사항 배포 되기 전에는 502 Bad Gateway 에서 403 Forbidden으로 에러 메세지 변경됨(스크린샷 참조)
