### PR TITLE
feat: 커스텀 스레드 만들어서 이메일 전송 비동기 처리

### DIFF
--- a/BE/src/main/java/com/example/p24zip/P24zipApplication.java
+++ b/BE/src/main/java/com/example/p24zip/P24zipApplication.java
@@ -1,20 +1,17 @@
 package com.example.p24zip;
 
+import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-import java.util.TimeZone;
-import org.springframework.scheduling.annotation.EnableAsync;
-
 @EnableJpaAuditing
 @SpringBootApplication
-@EnableAsync
 public class P24zipApplication {
 
-	public static void main(String[] args) {
-		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
-		SpringApplication.run(P24zipApplication.class, args);
-	}
+    public static void main(String[] args) {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+        SpringApplication.run(P24zipApplication.class, args);
+    }
 
 }

--- a/BE/src/main/java/com/example/p24zip/domain/user/controller/AuthController.java
+++ b/BE/src/main/java/com/example/p24zip/domain/user/controller/AuthController.java
@@ -5,11 +5,11 @@ import com.example.p24zip.domain.user.dto.request.OAuthSignupRequestDto;
 import com.example.p24zip.domain.user.dto.request.SignupRequestDto;
 import com.example.p24zip.domain.user.dto.request.VerifyEmailRequestCodeDto;
 import com.example.p24zip.domain.user.dto.request.VerifyEmailRequestDto;
-import com.example.p24zip.domain.user.dto.response.OAuthSignupResponseDto;
-import com.example.p24zip.domain.user.dto.response.FindPasswordResponseDto;
-import com.example.p24zip.domain.user.dto.response.VerifyEmailDataResponseDto;
 import com.example.p24zip.domain.user.dto.response.AccessTokenResponseDto;
+import com.example.p24zip.domain.user.dto.response.FindPasswordResponseDto;
 import com.example.p24zip.domain.user.dto.response.LoginResponseDto;
+import com.example.p24zip.domain.user.dto.response.OAuthSignupResponseDto;
+import com.example.p24zip.domain.user.dto.response.VerifyEmailDataResponseDto;
 import com.example.p24zip.domain.user.service.AuthService;
 import com.example.p24zip.global.response.ApiResponse;
 import jakarta.mail.MessagingException;
@@ -17,17 +17,15 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.io.UnsupportedEncodingException;
-import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.*;
-
 
 
 @RestController
@@ -48,7 +46,8 @@ public class AuthController {
     }
 
     @PostMapping("/verify-email")
-    public ResponseEntity<ApiResponse<CompletableFuture<VerifyEmailDataResponseDto>>> verifyEmail(@RequestBody @Valid VerifyEmailRequestDto requestDto)
+    public ResponseEntity<ApiResponse<VerifyEmailDataResponseDto>> verifyEmail(
+        @RequestBody @Valid VerifyEmailRequestDto requestDto)
         throws MessagingException, UnsupportedEncodingException {
 
         return ResponseEntity.ok(
@@ -57,7 +56,8 @@ public class AuthController {
     }
 
     @PostMapping("/verify-email-code")
-    public ResponseEntity<ApiResponse<Void>> verifyEmailCode(@RequestBody @Valid VerifyEmailRequestCodeDto requestDto) {
+    public ResponseEntity<ApiResponse<Void>> verifyEmailCode(
+        @RequestBody @Valid VerifyEmailRequestCodeDto requestDto) {
         authService.checkCode(requestDto);
 
         return ResponseEntity.ok(
@@ -70,12 +70,13 @@ public class AuthController {
         authService.checkExistNickname(nickname);
 
         return ResponseEntity.ok(
-            ApiResponse.ok("OK","사용 가능한 닉네임입니다.", null)
+            ApiResponse.ok("OK", "사용 가능한 닉네임입니다.", null)
         );
     }
 
     @PostMapping("/verify-password")
-    public ResponseEntity<ApiResponse<CompletableFuture<FindPasswordResponseDto>>> findPassword(@RequestBody @Valid VerifyEmailRequestDto requestDto)
+    public ResponseEntity<ApiResponse<FindPasswordResponseDto>> findPassword(
+        @RequestBody @Valid VerifyEmailRequestDto requestDto)
         throws MessagingException, UnsupportedEncodingException {
 
         return ResponseEntity.ok(
@@ -85,31 +86,32 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponseDto>> login(
-            @Valid @RequestBody LoginRequestDto requestDto, HttpServletResponse response) {
+        @Valid @RequestBody LoginRequestDto requestDto, HttpServletResponse response) {
         return ResponseEntity.ok(ApiResponse.ok(
-                "OK",
-                "로그인이 성공했습니다.",
-                authService.login(requestDto, response)
+            "OK",
+            "로그인이 성공했습니다.",
+            authService.login(requestDto, response)
         ));
     }
 
     @GetMapping("/reissue")
     public ResponseEntity<ApiResponse<AccessTokenResponseDto>> reissue(HttpServletRequest request) {
         return ResponseEntity.ok(ApiResponse.ok(
-                "OK",
-                "accessToken 재발급을 성공했습니다.",
-                authService.reissue(request)
+            "OK",
+            "accessToken 재발급을 성공했습니다.",
+            authService.reissue(request)
         ));
     }
 
     @DeleteMapping("/logout")
-    public ResponseEntity<ApiResponse<Object>> logout(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<Object>> logout(HttpServletRequest request,
+        HttpServletResponse response) {
         authService.logout(request, response);
 
         return ResponseEntity.ok(ApiResponse.ok(
-                "OK",
-                "로그아웃을 성공했습니다.",
-                null
+            "OK",
+            "로그아웃을 성공했습니다.",
+            null
         ));
     }
 

--- a/BE/src/main/java/com/example/p24zip/global/config/AsyncConfig.java
+++ b/BE/src/main/java/com/example/p24zip/global/config/AsyncConfig.java
@@ -1,0 +1,46 @@
+package com.example.p24zip.global.config;
+
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    /***
+     순간적인 부하 대응
+     */
+    @Bean(name = "customExecutor")
+    public Executor customExecutor() {
+
+        // 커스텀 스레드 생성기
+        ThreadFactory customFactory = runnable -> {
+            Thread t = new Thread(runnable);
+            t.setName("my-custom-thread-" + UUID.randomUUID());
+            return t;
+        };
+
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(
+            3,       // corePoolSize: 기본 스레드 수
+            5,                // maximumPoolSize: 최대 스레드 수
+            60L,              // keepAliveTime: 유휴(idele,할 일이 없이 대기 중인 상태) 스레드 유지 시간
+//            1. 작업이 끝나면 해당 스레드는 즉시 종료되지 않고 60초 동안 유휴 상태로 대기
+//            2. 그 60초 안에 새로운 작업이 들어오면 → 기존 유휴 스레드를 재사용
+//            3. 60초 동안 아무 일도 없으면 → 스레드는 자동 종료
+            TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(100), // 최대 100개 작업 대기
+//            Executors.defaultThreadFactory(), // 기본 스레드 생성기(새로운 스레드를 생성하는 방법을 캡슐화한 인터페이스)
+            customFactory,
+            new ThreadPoolExecutor.AbortPolicy() // 초과 시 예외 발생
+        );
+
+        return executor;
+    }
+}

--- a/BE/src/main/java/com/example/p24zip/global/service/AsyncService.java
+++ b/BE/src/main/java/com/example/p24zip/global/service/AsyncService.java
@@ -1,0 +1,90 @@
+package com.example.p24zip.global.service;
+
+import com.example.p24zip.global.exception.CustomException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import java.io.UnsupportedEncodingException;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class AsyncService {
+
+    private final JavaMailSender mailSender; // 메일 보내는 객체
+
+
+    @Async("customExecutor")
+    public void sendSignupEmail(String username, int codeNum, String mailAddress) {
+        MimeMessage message = mailSender.createMimeMessage();
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            helper.setFrom(new InternetAddress(mailAddress, "이사모음.zip"));
+            helper.setTo(username);
+            helper.setSubject("이사모음.zip 회원가입 인증 메일입니다.");
+            String text = String.format("<h1>인증 코드는 %d입니다.</h1>", codeNum);
+            helper.setText(text, true);
+
+            mailSender.send(message);
+        } catch (MessagingException | UnsupportedEncodingException e) {
+            log.error("[회원가입-이메일 작성 오류] username = {}", username, e);
+            System.out.println("회원가입-이메일 작성 오류: " + e.getMessage());
+            throw new CustomException("EMAIL_SEND_FAIL", "메일 전송 중 오류가 발생했습니다.");
+
+        } catch (MailException e) {
+            // 메일 서버 오류 (SMTP 접속 실패, 인증 실패 등)
+            log.error("[회원가입-메일 전송 실패] username = {}, codeNum = {}", username, codeNum, e);
+            System.out.println("회원가입-메일 전송 실패: " + e.getMessage());
+            throw new CustomException("EMAIL_SEND_FAIL", "메일 전송 중 오류가 발생했습니다.");
+
+        } catch (Exception e) {
+            // 그 외 예상치 못한 오류
+            log.error("[회원가입-알 수 없는 메일 전송 오류] username = {}", username, e);
+            System.out.println("회원가입-알 수 없는 메일 전송 오류: " + e.getMessage());
+            throw new CustomException("EMAIL_SEND_FAIL", "메일 전송 중 오류가 발생했습니다.");
+        }
+
+    }
+
+    @Async("customExecutor")
+    public void sendFindPassword(String username, String tempJwt, String mailAddress,
+        String origin) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            helper.setFrom(new InternetAddress(mailAddress, "이사모음.zip"));
+            helper.setTo(username);
+            helper.setSubject("이사모음.zip 비밀번호 인증 메일입니다.");
+            String text = String.format(
+                "<h1>해당 링크로 접속 후 비밀번호를 변경해 주세요. 이용시간은 10분 입니다. 이용시간이 끝나거나 비밀번호 변경 후에는 해당 링크를 이용할 수 없습니다.</h1><p>%s/newpassword?query=%s</p>",
+                origin, tempJwt);
+            helper.setText(text, true);
+
+            mailSender.send(message);
+        } catch (MessagingException | UnsupportedEncodingException e) {
+            log.error("[비밀번호 찾기-이메일 작성 오류] username = {}", username, e);
+            System.out.println("비밀번호 찾기-이메일 작성 오류: " + e.getMessage());
+            throw new CustomException("EMAIL_SEND_FAIL", "메일 전송 중 오류가 발생했습니다.");
+
+        } catch (MailException e) {
+            // 메일 서버 오류 (SMTP 접속 실패, 인증 실패 등)
+            log.error("[비밀번호 찾기-메일 전송 실패] username = {}", username, e);
+            System.out.println("비밀번호 찾기-메일 전송 실패: " + e.getMessage());
+            throw new CustomException("EMAIL_SEND_FAIL", "메일 전송 중 오류가 발생했습니다.");
+
+        } catch (Exception e) {
+            // 그 외 예상치 못한 오류
+            log.error("[비밀번호 찾기-알 수 없는 메일 전송 오류] username = {}", username, e);
+            System.out.println("비밀번호 찾기-알 수 없는 메일 전송 오류: " + e.getMessage());
+            throw new CustomException("EMAIL_SEND_FAIL", "메일 전송 중 오류가 발생했습니다.");
+        }
+    }
+
+}


### PR DESCRIPTION
## 📝 변경 사항

- 이메일 전송 비동기를 처리할 때 스레드 설정을 스레드 수, 유휴시간, 큐 사이즈 등을 해당 로직에 맞게 커스텀하여 비동기 처리하는 메서드 실행 시 설정한 커스텀 스레드풀을 이용하도록 함

## 📸 스크린샷
- ### 회원가입 인증코드 이메일 전송
![image](https://github.com/user-attachments/assets/b6ca4020-a1e8-44aa-bcb9-8edfa3e9168b)

- ### 비밀번호 찾기 이메일 전송
![image](https://github.com/user-attachments/assets/2192af84-b290-4d4e-b995-399ac9ed60b2)


## 📌 참고 사항

