### PR TITLE
[fix] 비동기 로직에서 에러 났을 때 에러 전달 안되던 문제 해결

### DIFF
--- a/BE/src/main/java/com/example/p24zip/domain/movingPlan/service/NotificationService.java
+++ b/BE/src/main/java/com/example/p24zip/domain/movingPlan/service/NotificationService.java
@@ -63,8 +63,8 @@ public class NotificationService {
      * 알림을 Redis 해시에 저장
      *
      * @return void
-     * @apiNote notifications:알림 받을 사용자 아이디+HashId(UUID로 만든 String) 를 key로  알림 받을 사용자 아이디, 어떤 메서드로
-     * 저장된 데이터인지 나타낼 type, 알림내용, 알림이 발생한 시간, 알림 읽음 여부, redisKey
+     * @apiNote "notifications:알림 받을 사용자 아이디"를 Key로 "UUID로 만든 String"를 Field로 {알림 받을 사용자 아이디, 어떤
+     * 메서드로 저장된 데이터인지 나타낼 type, 알림내용, 알림이 발생한 시간, 알림 읽음 여부}를 Value로 받음
      */
     public void saveNotificationToRedis(RedisNotificationDto notification) {
 

--- a/BE/src/main/java/com/example/p24zip/global/service/AsyncService.java
+++ b/BE/src/main/java/com/example/p24zip/global/service/AsyncService.java
@@ -1,10 +1,12 @@
 package com.example.p24zip.global.service;
 
+import com.example.p24zip.global.exception.CustomErrorCode;
 import com.example.p24zip.global.exception.CustomException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import java.io.UnsupportedEncodingException;
+import java.util.concurrent.CompletableFuture;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.MailException;
@@ -12,20 +14,20 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import com.example.p24zip.global.exception.CustomErrorCode;
 
 @Service
 @AllArgsConstructor
 @Slf4j
+
 public class AsyncService {
 
     private final JavaMailSender mailSender; // 메일 보내는 객체
 
-
     @Async("customExecutor")
-
-    public void sendMail(String to, String subject, String htmlContent, String fromName,
+    public CompletableFuture<Void> sendMail(String to, String subject, String htmlContent,
+        String fromName,
         String mailAddress) {
+
         try {
             MimeMessage message = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
@@ -36,38 +38,44 @@ public class AsyncService {
             helper.setText(htmlContent, true);
 
             mailSender.send(message);
+            return CompletableFuture.completedFuture(null);
 
         } catch (MessagingException | UnsupportedEncodingException e) {
             log.error("[이메일 작성 오류] username = {}", to, e);
-            System.out.println("회원가입-이메일 작성 오류: " + e.getMessage());
-            throw new CustomException(CustomErrorCode.EMAIL_SEND_FAIL);
+            System.out.println("이메일 작성 오류: " + e.getMessage());
+            return CompletableFuture.failedFuture(
+                new CustomException(CustomErrorCode.EMAIL_SEND_FAIL));
 
         } catch (MailException e) {
             // 메일 서버 오류 (SMTP 접속 실패, 인증 실패 등)
             log.error("[메일 전송 실패] username = {}", to, e);
-            System.out.println("회원가입-메일 전송 실패: " + e.getMessage());
-            throw new CustomException(CustomErrorCode.EMAIL_SEND_FAIL);
+            System.out.println("메일 전송 실패: " + e.getMessage());
+            return CompletableFuture.failedFuture(
+                new CustomException(CustomErrorCode.EMAIL_SEND_FAIL));
 
         } catch (Exception e) {
             // 그 외 예상치 못한 오류
             log.error("[알 수 없는 메일 전송 오류] username = {}", to, e);
-            System.out.println("회원가입-알 수 없는 메일 전송 오류: " + e.getMessage());
-            throw new CustomException(CustomErrorCode.EMAIL_SEND_FAIL);
+            System.out.println("알 수 없는 메일 전송 오류: " + e.getMessage());
+            return CompletableFuture.failedFuture(
+                new CustomException(CustomErrorCode.EMAIL_SEND_FAIL));
         }
     }
 
-
-    public void sendSignupEmail(String to, int code, String mailAddress) {
+    @Async("customExecutor")
+    public CompletableFuture<Void> sendSignupEmail(String to, int code, String mailAddress) {
         String subject = "이사모음.zip 회원가입 인증 메일입니다.";
         String html = String.format("<h1>인증 코드는 %d입니다.</h1>", code);
-        sendMail(to, subject, html, "이사모음.zip", mailAddress);
+        return sendMail(to, subject, html, "이사모음.zip", mailAddress);
     }
 
-    public void sendFindPassword(String to, String token, String origin, String mailAddress) {
+    @Async("customExecutor")
+    public CompletableFuture<Void> sendFindPassword(String to, String token, String origin,
+        String mailAddress) {
         String subject = "이사모음.zip 비밀번호 인증 메일입니다.";
         String link = String.format("%s/newpassword?query=%s", origin, token);
         String html = "<h1>해당 링크로 접속 후 비밀번호를 변경해 주세요. 이용시간은 10분 입니다.</h1><p>" + link + "</p>";
-        sendMail(to, subject, html, "이사모음.zip", mailAddress);
+        return sendMail(to, subject, html, "이사모음.zip", mailAddress);
     }
 
 


### PR DESCRIPTION
## 📝 변경 사항

- 비동기 로직 void에서 CompletableFuture<Void>로 타입 변환
- 비동기 로직의 실행 결과와 상관없이 로직이 실행되지 않도록 .join()으로 대기 후 CompletionException, Throwable 으로 비동기 에러 받아오기

## 📸 스크린샷


