### PR TITLE
[fix] 메일 서버 오류로 에러 반환시 상태코드 400이 아닌 500으로 뜨게 수정

### DIFF
--- a/BE/src/main/java/com/example/p24zip/domain/user/service/AuthService.java
+++ b/BE/src/main/java/com/example/p24zip/domain/user/service/AuthService.java
@@ -24,6 +24,7 @@ import com.example.p24zip.domain.user.dto.response.VerifyEmailDataResponseDto;
 import com.example.p24zip.domain.user.entity.Role;
 import com.example.p24zip.domain.user.entity.User;
 import com.example.p24zip.domain.user.repository.UserRepository;
+import com.example.p24zip.global.exception.ConnectMailException;
 import com.example.p24zip.global.exception.CustomErrorCode;
 import com.example.p24zip.global.exception.CustomException;
 import com.example.p24zip.global.exception.ResourceNotFoundException;
@@ -140,8 +141,10 @@ public class AuthService {
             Throwable cause = e.getCause();
             if (cause instanceof CustomException customEx) {
                 throw customEx;
+            } else if (cause instanceof ConnectMailException connectMailEx) {
+                throw connectMailEx;
             }
-            throw new CustomException(CustomErrorCode.EMAIL_SEND_FAIL);
+
         }
 
         ZonedDateTime expiredAt = saveCodeToRedis(username, codeNum);
@@ -231,8 +234,9 @@ public class AuthService {
             Throwable cause = e.getCause();
             if (cause instanceof CustomException customEx) {
                 throw customEx;
+            } else if (cause instanceof ConnectMailException connectMailEx) {
+                throw connectMailEx;
             }
-            throw new CustomException(CustomErrorCode.EMAIL_SEND_FAIL);
         }
 
         ZonedDateTime date = ZonedDateTime.now().plusMinutes(2);

--- a/BE/src/main/java/com/example/p24zip/global/exception/ConnectMailException.java
+++ b/BE/src/main/java/com/example/p24zip/global/exception/ConnectMailException.java
@@ -1,0 +1,15 @@
+package com.example.p24zip.global.exception;
+
+import lombok.Getter;
+import org.springframework.mail.MailException;
+
+@Getter
+public class ConnectMailException extends MailException {
+
+    private final String errorCode;
+
+    public ConnectMailException(CustomErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.getCode();
+    }
+}

--- a/BE/src/main/java/com/example/p24zip/global/exception/GlobalExceptionHandler.java
+++ b/BE/src/main/java/com/example/p24zip/global/exception/GlobalExceptionHandler.java
@@ -3,7 +3,6 @@ package com.example.p24zip.global.exception;
 import com.example.p24zip.domain.chat.dto.response.ChatsErrorResponseDto;
 import com.example.p24zip.global.response.ApiResponse;
 import java.util.NoSuchElementException;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,9 +15,9 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
-import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 
 @RestControllerAdvice
@@ -33,10 +32,11 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Void>> MethodArgumentNotValid(MethodArgumentNotValidException ex) {
+    public ResponseEntity<ApiResponse<Void>> MethodArgumentNotValid(
+        MethodArgumentNotValidException ex) {
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error("BAD_REQUEST", "필수값이 누락되거나 형식이 올바르지 않습니다."));
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error("BAD_REQUEST", "필수값이 누락되거나 형식이 올바르지 않습니다."));
     }
 
     //    @ExceptionHandler(Exception.class)
@@ -56,15 +56,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(TokenException.class)
     public ResponseEntity<ApiResponse<Void>> Token(TokenException ex) {
         return ResponseEntity
-                .status(HttpStatus.UNAUTHORIZED)
-                .body(ApiResponse.error("INVALID_TOKEN", "토큰이 유효하지 않습니다."));
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(ApiResponse.error("INVALID_TOKEN", "토큰이 유효하지 않습니다."));
     }
 
     @ExceptionHandler(BadCredentialsException.class)
     public ResponseEntity<ApiResponse<Void>> BadCredentials(BadCredentialsException ex) {
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error("INVALID_CREDENTIALS", "이메일 또는 비밀번호가 올바르지 않습니다."));
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error("INVALID_CREDENTIALS", "이메일 또는 비밀번호가 올바르지 않습니다."));
     }
 
     @ExceptionHandler(GeocoderExceptionHandler.class)
@@ -78,7 +78,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> GeocoderConnectHandler(WebClientRequestException ex) {
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(ApiResponse.error("GEOCODER_API_CONNECT_ERROR","좌표 변경 API에서 연결 오류가 발생했습니다."));
+            .body(ApiResponse.error("GEOCODER_API_CONNECT_ERROR", "좌표 변경 API에서 연결 오류가 발생했습니다."));
     }
 
     @ExceptionHandler(WebClientResponseException.class)
@@ -87,29 +87,33 @@ public class GlobalExceptionHandler {
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(ApiResponse.error("GEOCODER_API_CONNECT_ERROR", "좌표 변경 API에서 연결 오류가 발생했습니다."));
     }
+
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ApiResponse<Void>> HttpMessageNotReadable(HttpMessageNotReadableException ex){
+    public ResponseEntity<ApiResponse<Void>> HttpMessageNotReadable(
+        HttpMessageNotReadableException ex) {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(ApiResponse.error("BAD_REQUEST", "필수값이 누락되거나 형식이 올바르지 않습니다."));
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<ApiResponse<Void>> MethodArgumentTypeMismatch (MethodArgumentTypeMismatchException  ex){
+    public ResponseEntity<ApiResponse<Void>> MethodArgumentTypeMismatch(
+        MethodArgumentTypeMismatchException ex) {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(ApiResponse.error("BAD_REQUEST", "입력 형식이 올바르지 않습니다."));
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
-    public ResponseEntity<ApiResponse<Void>> MissingServletRequestParameter (MissingServletRequestParameterException  ex) {
+    public ResponseEntity<ApiResponse<Void>> MissingServletRequestParameter(
+        MissingServletRequestParameterException ex) {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(ApiResponse.error("BAD_REQUEST", "필수값이 누락되었습니다."));
     }
 
     @ExceptionHandler(NoSuchElementException.class)
-    public ResponseEntity<ApiResponse<Void>> NoExistId_handler (NoSuchElementException ex) {
+    public ResponseEntity<ApiResponse<Void>> NoExistId_handler(NoSuchElementException ex) {
         return ResponseEntity
             .status(HttpStatus.NOT_FOUND)
             .body(ApiResponse.error("NOT_FOUND", "존재하지 않는 id입니다."));
@@ -117,8 +121,17 @@ public class GlobalExceptionHandler {
 
     @MessageExceptionHandler(StompTokenException.class)
     @SendTo("/topic/{movingPlanId}/errors")
-    public ChatsErrorResponseDto normalChatExceptionHandler(StompTokenException e,  @DestinationVariable Long movingPlanId) {
-        return new ChatsErrorResponseDto("INVALID_TOKEN","토큰이 유효하지 않습니다.", e.getMessage());
+    public ChatsErrorResponseDto normalChatExceptionHandler(StompTokenException e,
+        @DestinationVariable Long movingPlanId) {
+        return new ChatsErrorResponseDto("INVALID_TOKEN", "토큰이 유효하지 않습니다.", e.getMessage());
     }
+
+    @ExceptionHandler(ConnectMailException.class)
+    public ResponseEntity<ApiResponse<Object>> handleMailException(ConnectMailException ex) {
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)  // 500
+            .body(ApiResponse.error(ex.getErrorCode(), ex.getMessage()));
+    }
+
 }
 

--- a/BE/src/main/java/com/example/p24zip/global/service/AsyncService.java
+++ b/BE/src/main/java/com/example/p24zip/global/service/AsyncService.java
@@ -1,5 +1,6 @@
 package com.example.p24zip.global.service;
 
+import com.example.p24zip.global.exception.ConnectMailException;
 import com.example.p24zip.global.exception.CustomErrorCode;
 import com.example.p24zip.global.exception.CustomException;
 import jakarta.mail.MessagingException;
@@ -51,7 +52,7 @@ public class AsyncService {
             log.error("[메일 전송 실패] username = {}", to, e);
             System.out.println("메일 전송 실패: " + e.getMessage());
             return CompletableFuture.failedFuture(
-                new CustomException(CustomErrorCode.EMAIL_SEND_FAIL));
+                new ConnectMailException(CustomErrorCode.EMAIL_SEND_FAIL));
 
         } catch (Exception e) {
             // 그 외 예상치 못한 오류


### PR DESCRIPTION
## 📝 변경 사항

- ConnectMailException 예외 클래스 생성
- GlobalExceptionHandler에서 ConnectMailException 에러 500으로 처리되게 설정

## 📸 스크린샷
<img width="1367" height="1066" alt="image" src="https://github.com/user-attachments/assets/9b03d302-9f60-49ea-8916-141d32af1b4b" />
   <img width="1375" height="919" alt="image" src="https://github.com/user-attachments/assets/3b7df5c7-f428-41f7-9c65-3d04af9bfb29" />


