### PR TITLE
[refactor] 메일 전송 로직 JavaMailSender에서 Simple Java Mail로 마이그레이션

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -45,9 +45,11 @@ dependencies {
     // dockercompose 자동실행
     developmentOnly "org.springframework.boot:spring-boot-docker-compose"
 
-    // SMTP
-    implementation 'org.springframework.boot:spring-boot-starter-mail'
-    implementation 'com.sun.mail:jakarta.mail:2.0.1'  // 최신 jakarta.mail 추가
+    // reuse SMTP connection
+    implementation 'org.simplejavamail:simple-java-mail:8.0.0'
+    implementation 'com.sun.mail:jakarta.mail:2.0.1'
+    implementation 'jakarta.activation:jakarta.activation-api:2.1.1'
+
 
     // WebFlux 포함 (WebClient 사용 가능)
     implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/BE/src/main/java/com/example/p24zip/global/config/AsyncConfig.java
+++ b/BE/src/main/java/com/example/p24zip/global/config/AsyncConfig.java
@@ -28,17 +28,17 @@ public class AsyncConfig {
         };
 
         ThreadPoolExecutor executor = new ThreadPoolExecutor(
-            3,       // corePoolSize: 기본 스레드 수
-            5,                // maximumPoolSize: 최대 스레드 수
+            10,       // corePoolSize: 기본 스레드 수
+            20,                // maximumPoolSize: 최대 스레드 수
             60L,              // keepAliveTime: 유휴(idele,할 일이 없이 대기 중인 상태) 스레드 유지 시간
 //            1. 작업이 끝나면 해당 스레드는 즉시 종료되지 않고 60초 동안 유휴 상태로 대기
 //            2. 그 60초 안에 새로운 작업이 들어오면 → 기존 유휴 스레드를 재사용
 //            3. 60초 동안 아무 일도 없으면 → 스레드는 자동 종료
             TimeUnit.SECONDS,
-            new LinkedBlockingQueue<>(100), // 최대 100개 작업 대기
+            new LinkedBlockingQueue<>(1000), // 최대 100개 작업 대기
 //            Executors.defaultThreadFactory(), // 기본 스레드 생성기(새로운 스레드를 생성하는 방법을 캡슐화한 인터페이스)
             customFactory,
-            new ThreadPoolExecutor.AbortPolicy() // 초과 시 예외 발생
+            new ThreadPoolExecutor.CallerRunsPolicy() // queue 넘치면 메인 스레드에서 실행
         );
 
         return executor;

--- a/BE/src/main/java/com/example/p24zip/global/config/MailConfig.java
+++ b/BE/src/main/java/com/example/p24zip/global/config/MailConfig.java
@@ -1,12 +1,11 @@
 package com.example.p24zip.global.config;
 
+import org.simplejavamail.api.mailer.Mailer;
+import org.simplejavamail.api.mailer.config.TransportStrategy;
+import org.simplejavamail.mailer.MailerBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.JavaMailSenderImpl;
-
-import java.util.Properties;
 
 @Configuration
 public class MailConfig {
@@ -18,28 +17,12 @@ public class MailConfig {
     private String mailpassword;
 
     @Bean
-    public JavaMailSender javaMailService() {
-        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
-
-        javaMailSender.setHost("smtp.gmail.com");
-        javaMailSender.setUsername(mailusername);
-        javaMailSender.setPassword(mailpassword);
-
-        javaMailSender.setPort(465);
-
-        javaMailSender.setJavaMailProperties(getMailProperties());
-
-        return javaMailSender;
-    }
-
-    private Properties getMailProperties() {
-        Properties properties = new Properties();
-        properties.setProperty("mail.transport.protocol", "smtp");
-        properties.setProperty("mail.smtp.auth", "true");
-        properties.setProperty("mail.smtp.starttls.enable", "true");
-        properties.setProperty("mail.debug", "true");
-        properties.setProperty("mail.smtp.ssl.trust","smtp.gmail.com");
-        properties.setProperty("mail.smtp.ssl.enable","true");
-        return properties;
+    public Mailer mailer() {
+        return MailerBuilder
+            .withSMTPServer("smtp.gmail.com", 587, mailusername, mailpassword)
+            .withTransportStrategy(TransportStrategy.SMTP_TLS)
+            .withSessionTimeout(5000)
+            .async() // 내부 큐 사용 가능하지만, 우리는 외부에서 제어할 예정
+            .buildMailer();
     }
 }

--- a/BE/src/main/java/com/example/p24zip/global/service/AsyncService.java
+++ b/BE/src/main/java/com/example/p24zip/global/service/AsyncService.java
@@ -3,16 +3,13 @@ package com.example.p24zip.global.service;
 import com.example.p24zip.global.exception.ConnectMailException;
 import com.example.p24zip.global.exception.CustomErrorCode;
 import com.example.p24zip.global.exception.CustomException;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.InternetAddress;
-import jakarta.mail.internet.MimeMessage;
-import java.io.UnsupportedEncodingException;
 import java.util.concurrent.CompletableFuture;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.mail.MailException;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
+import org.simplejavamail.MailException;
+import org.simplejavamail.api.email.Email;
+import org.simplejavamail.api.mailer.Mailer;
+import org.simplejavamail.email.EmailBuilder;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -22,7 +19,7 @@ import org.springframework.stereotype.Service;
 
 public class AsyncService {
 
-    private final JavaMailSender mailSender; // 메일 보내는 객체
+    private final Mailer mailSender; // 메일 보내는 객체
 
     @Async("customExecutor")
     public CompletableFuture<Void> sendMail(String to, String subject, String htmlContent,
@@ -30,22 +27,16 @@ public class AsyncService {
         String mailAddress) {
 
         try {
-            MimeMessage message = mailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            Email email = EmailBuilder.startingBlank()
+                .from(fromName, mailAddress)
+                .to(to)
+                .withSubject(subject)
+                .withHTMLText(htmlContent)
+                .buildEmail();
 
-            helper.setFrom(new InternetAddress(mailAddress, fromName));
-            helper.setTo(to);
-            helper.setSubject(subject);
-            helper.setText(htmlContent, true);
-
-            mailSender.send(message);
+            mailSender.sendMail(email);
+            log.info("[메일 발송 성공] to={}, subject={}", to, subject);
             return CompletableFuture.completedFuture(null);
-
-        } catch (MessagingException | UnsupportedEncodingException e) {
-            log.error("[이메일 작성 오류] username = {}", to, e);
-            System.out.println("이메일 작성 오류: " + e.getMessage());
-            return CompletableFuture.failedFuture(
-                new CustomException(CustomErrorCode.EMAIL_SEND_FAIL));
 
         } catch (MailException e) {
             // 메일 서버 오류 (SMTP 접속 실패, 인증 실패 등)


### PR DESCRIPTION
## 📝 변경 사항

- 메일 전송 로직 비동기 설정과 스레드풀 조정해도 실행 속도 느려서 Simple Java Mail 라이브러리로 마이그레이션

## 📸 스크린샷


## 📌 참고 사항
- JavaMailSender : Spring Framework 내장되어 인터페이스로 매 이메일 전송마다 SMTP 서버와의 연결/해제하며 메일 전송 로직 성능 저하
- Simple Java Mail : 외부 라이브러리로 SMTP 커넥션풀이 기본 내장되어 커넥션 재사용 및 전송 최적화를 지원하여 메일 전송 로직 성능 향상