### PR TITLE
[feat] 메일 전송 로직에 타임아웃 적용 및 스레드 인터럽트 적용하여 예외 처리 속도 개선

### DIFF
--- a/BE/src/main/java/com/example/p24zip/global/config/AsyncConfig.java
+++ b/BE/src/main/java/com/example/p24zip/global/config/AsyncConfig.java
@@ -1,8 +1,12 @@
 package com.example.p24zip.global.config;
 
+
 import java.util.UUID;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -14,33 +18,35 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @EnableAsync
 public class AsyncConfig {
 
-    /***
-     순간적인 부하 대응
-     */
+    // 일반적인 비동기 작업용 Executor
     @Bean(name = "customExecutor")
     public Executor customExecutor() {
-
-        // 커스텀 스레드 생성기
         ThreadFactory customFactory = runnable -> {
             Thread t = new Thread(runnable);
             t.setName("my-custom-thread-" + UUID.randomUUID());
             return t;
         };
 
-        ThreadPoolExecutor executor = new ThreadPoolExecutor(
-            3,       // corePoolSize: 기본 스레드 수
-            5,                // maximumPoolSize: 최대 스레드 수
-            60L,              // keepAliveTime: 유휴(idele,할 일이 없이 대기 중인 상태) 스레드 유지 시간
-//            1. 작업이 끝나면 해당 스레드는 즉시 종료되지 않고 60초 동안 유휴 상태로 대기
-//            2. 그 60초 안에 새로운 작업이 들어오면 → 기존 유휴 스레드를 재사용
-//            3. 60초 동안 아무 일도 없으면 → 스레드는 자동 종료
-            TimeUnit.SECONDS,
-            new LinkedBlockingQueue<>(100), // 최대 100개 작업 대기
-//            Executors.defaultThreadFactory(), // 기본 스레드 생성기(새로운 스레드를 생성하는 방법을 캡슐화한 인터페이스)
+        return new ThreadPoolExecutor(
+            3, 5,
+            60L, TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(100),
             customFactory,
-            new ThreadPoolExecutor.AbortPolicy() // 초과 시 예외 발생
+            new ThreadPoolExecutor.AbortPolicy()
         );
-
-        return executor;
     }
+
+    // 메일 타임아웃 감시용 Executor (즉시 실행)
+    @Bean(name = "mailTimeoutExecutor")
+    public ExecutorService mailTimeoutExecutor() {
+        return new ThreadPoolExecutor(
+            0, 30,
+            60L, TimeUnit.SECONDS,
+            new SynchronousQueue<>(), // 큐 없이 바로 실행 or reject
+            Executors.defaultThreadFactory(),
+            new ThreadPoolExecutor.AbortPolicy()
+        );
+    }
+
+    
 }

--- a/BE/src/main/java/com/example/p24zip/global/config/AsyncConfig.java
+++ b/BE/src/main/java/com/example/p24zip/global/config/AsyncConfig.java
@@ -28,11 +28,13 @@ public class AsyncConfig {
         };
 
         return new ThreadPoolExecutor(
-            3, 5,
-            60L, TimeUnit.SECONDS,
-            new LinkedBlockingQueue<>(100),
+            3,
+            5,
+            60L, // 스레드 keepAliveTime 60초
+            TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(100), // 최대 100개 작업 대기
             customFactory,
-            new ThreadPoolExecutor.AbortPolicy()
+            new ThreadPoolExecutor.AbortPolicy() // 초과 시 예외 발생
         );
     }
 
@@ -40,13 +42,15 @@ public class AsyncConfig {
     @Bean(name = "mailTimeoutExecutor")
     public ExecutorService mailTimeoutExecutor() {
         return new ThreadPoolExecutor(
-            0, 30,
-            60L, TimeUnit.SECONDS,
+            0,
+            30,
+            60L,
+            TimeUnit.SECONDS,
             new SynchronousQueue<>(), // 큐 없이 바로 실행 or reject
             Executors.defaultThreadFactory(),
             new ThreadPoolExecutor.AbortPolicy()
         );
     }
 
-    
+
 }

--- a/BE/src/main/java/com/example/p24zip/global/redis/RedisNotificationDto.java
+++ b/BE/src/main/java/com/example/p24zip/global/redis/RedisNotificationDto.java
@@ -22,7 +22,7 @@ public class RedisNotificationDto implements Serializable {
     private boolean read;
 
     @Builder
-    public RedisNotificationDto(String username, String type, String message, String redisKey) {
+    public RedisNotificationDto(String username, String type, String message) {
         this.id = java.util.UUID.randomUUID().toString();
         this.username = username;
         this.type = type;

--- a/BE/src/main/java/com/example/p24zip/global/service/AsyncService.java
+++ b/BE/src/main/java/com/example/p24zip/global/service/AsyncService.java
@@ -83,7 +83,6 @@ public class AsyncService {
         });
     }
 
-    // MailConfig를 사용한 회원가입 이메일 전송
     @Qualifier("customExecutor")
     public CompletableFuture<Object> sendSignupEmail(String to, int code, String mailAddress) {
         String subject = "이사모음.zip 회원가입 인증 메일입니다.";
@@ -91,7 +90,6 @@ public class AsyncService {
         return sendEmail(to, subject, content, mailAddress);
     }
 
-    // MailConfig를 사용한 비밀번호 찾기 이메일 전송
     @Qualifier("customExecutor")
     public CompletableFuture<Object> sendFindPassword(String to, String token, String origin,
         String mailAddress) {

--- a/BE/src/main/java/com/example/p24zip/global/service/AsyncService.java
+++ b/BE/src/main/java/com/example/p24zip/global/service/AsyncService.java
@@ -2,82 +2,105 @@ package com.example.p24zip.global.service;
 
 import com.example.p24zip.global.exception.ConnectMailException;
 import com.example.p24zip.global.exception.CustomErrorCode;
-import com.example.p24zip.global.exception.CustomException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import java.io.UnsupportedEncodingException;
 import java.util.concurrent.CompletableFuture;
-import lombok.AllArgsConstructor;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Slf4j
-
 public class AsyncService {
 
-    private final JavaMailSender mailSender; // 메일 보내는 객체
+    private static final long MAIL_TIMEOUT_SECONDS = 2;
 
-    @Async("customExecutor")
-    public CompletableFuture<Void> sendMail(String to, String subject, String htmlContent,
-        String fromName,
-        String mailAddress) {
+    private final JavaMailSender mailSender;
 
-        try {
-            MimeMessage message = mailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+    // 메일 전송을 실행할 전용 Executor (강제 타임아웃 처리를 위해)
+    @Qualifier("mailTimeoutExecutor")
+    private final ExecutorService mailTimeoutExecutor;
 
-            helper.setFrom(new InternetAddress(mailAddress, fromName));
-            helper.setTo(to);
-            helper.setSubject(subject);
-            helper.setText(htmlContent, true);
+    @Qualifier("customExecutor")
+    public CompletableFuture<Object> sendEmail(String to, String subject,
+        String htmlContent, String mailAddress) {
+        System.out.println("현재 스레드: " + Thread.currentThread().getName());
 
-            mailSender.send(message);
-            return CompletableFuture.completedFuture(null);
+        return CompletableFuture.supplyAsync(() -> {
+            Future<?> future = mailTimeoutExecutor.submit(() -> {
+                System.out.println("현재 스레드: " + Thread.currentThread().getName());
 
-        } catch (MessagingException | UnsupportedEncodingException e) {
-            log.error("[이메일 작성 오류] username = {}", to, e);
-            System.out.println("이메일 작성 오류: " + e.getMessage());
-            return CompletableFuture.failedFuture(
-                new CustomException(CustomErrorCode.EMAIL_SEND_FAIL));
+                try {
+                    MimeMessage message = mailSender.createMimeMessage();
+                    MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
-        } catch (MailException e) {
-            // 메일 서버 오류 (SMTP 접속 실패, 인증 실패 등)
-            log.error("[메일 전송 실패] username = {}", to, e);
-            System.out.println("메일 전송 실패: " + e.getMessage());
-            return CompletableFuture.failedFuture(
-                new ConnectMailException(CustomErrorCode.EMAIL_SEND_FAIL));
+                    helper.setFrom(new InternetAddress(mailAddress, "이사모음.zip"));
+                    helper.setTo(to);
+                    helper.setSubject(subject);
+                    helper.setText(htmlContent, true);
 
-        } catch (Exception e) {
-            // 그 외 예상치 못한 오류
-            log.error("[알 수 없는 메일 전송 오류] username = {}", to, e);
-            System.out.println("알 수 없는 메일 전송 오류: " + e.getMessage());
-            return CompletableFuture.failedFuture(
-                new CustomException(CustomErrorCode.EMAIL_SEND_FAIL));
-        }
+                    mailSender.send(message);
+                    log.info("메일 전송 성공: {}", to);
+
+                } catch (MessagingException | MailException | UnsupportedEncodingException e) {
+                    log.error("[메일 전송 실패] to = {}", to, e);
+                    throw new ConnectMailException(CustomErrorCode.EMAIL_SEND_FAIL);
+                }
+            });
+
+            try {
+                // 타임아웃 제한 내에 완료되기를 기다림
+                future.get(MAIL_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+                future.cancel(true); // 타임아웃 시 강제 인터럽트
+                log.error("[메일 전송 타임아웃] {}초 초과: {}", MAIL_TIMEOUT_SECONDS, to);
+                throw new ConnectMailException(CustomErrorCode.EMAIL_SEND_FAIL);
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof ConnectMailException ce) {
+                    throw ce;
+                }
+                log.error("[메일 전송 중 예외 발생] username = {}", to, e);
+                throw new ConnectMailException(CustomErrorCode.EMAIL_SEND_FAIL);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("[메일 전송 인터럽트] {}", to, e);
+                throw new ConnectMailException(CustomErrorCode.EMAIL_SEND_FAIL);
+            }
+
+            return null;
+        });
     }
 
-    @Async("customExecutor")
-    public CompletableFuture<Void> sendSignupEmail(String to, int code, String mailAddress) {
+    // MailConfig를 사용한 회원가입 이메일 전송
+    @Qualifier("customExecutor")
+    public CompletableFuture<Object> sendSignupEmail(String to, int code, String mailAddress) {
         String subject = "이사모음.zip 회원가입 인증 메일입니다.";
-        String html = String.format("<h1>인증 코드는 %d입니다.</h1>", code);
-        return sendMail(to, subject, html, "이사모음.zip", mailAddress);
+        String content = String.format("<h1>인증 코드는 %d입니다.</h1>", code);
+        return sendEmail(to, subject, content, mailAddress);
     }
 
-    @Async("customExecutor")
-    public CompletableFuture<Void> sendFindPassword(String to, String token, String origin,
+    // MailConfig를 사용한 비밀번호 찾기 이메일 전송
+    @Qualifier("customExecutor")
+    public CompletableFuture<Object> sendFindPassword(String to, String token, String origin,
         String mailAddress) {
         String subject = "이사모음.zip 비밀번호 인증 메일입니다.";
         String link = String.format("%s/newpassword?query=%s", origin, token);
-        String html = "<h1>해당 링크로 접속 후 비밀번호를 변경해 주세요. 이용시간은 10분 입니다.</h1><p>" + link + "</p>";
-        return sendMail(to, subject, html, "이사모음.zip", mailAddress);
+        String content = String.format(
+            "<h1>해당 링크로 접속 후 비밀번호를 변경해 주세요. 이용시간은 10분 입니다.</h1>\n <p>%s</p>",
+            link);
+        return sendEmail(to, subject, content, mailAddress);
     }
-
 
 }


### PR DESCRIPTION
## 📝 변경 사항
- AsyncConfig에 비동기를 처리할 스레드와 타임아웃을 적용할 스레드 2개의 스레드 빈을 생성
- AsyncService에서 메일 전송에 타임아웃 스레드를 따로 적용 시켜서 일정시간 동안 완료 안되면 중단 시키고 바로 예외 처리 되도록 설정


## 📸 스크린샷


## 📌 참고 사항
-  `@Qualifier` : 의존성 주입 대상이 둘 이상 있을 때 어떤 빈(Bean)을 주입할지 지정하는 데 사용하는 어노테이션
- AsyncConfig에 2개의 빈이 생기면서 AsyncService에 `@Async` 어노테이션을 `@Qualifier`으로 변경
