### PR TITLE
[fix] 메일 전송은 성공했는데 타임 아웃 예외가 발생하는 문제 타임아웃 시간 늘려서 해결

### DIFF
--- a/BE/src/main/java/com/example/p24zip/global/service/AsyncService.java
+++ b/BE/src/main/java/com/example/p24zip/global/service/AsyncService.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class AsyncService {
 
-    private static final long MAIL_TIMEOUT_SECONDS = 2;
+    private static final long MAIL_TIMEOUT_SECONDS = 4;
 
     private final JavaMailSender mailSender;
 


### PR DESCRIPTION
## 📝 변경 사항

- AsyncService의 MAIL_TIMEOUT_SECONDS 값 2 → 4 로 변경


