### PR TITLE
[test(benchmark] 메세지 가져오는 기능 실행 시 chat JPA의 쿼리 메서드, JPQL와 Reids에 따른 성능 차이 테스트

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.3'
     id 'io.spring.dependency-management' version '1.1.7'
+
+    id 'me.champeau.jmh' version '0.6.6' // JMH Gradle 플러그인
 }
 
 group = 'com.example'
@@ -61,8 +63,14 @@ dependencies {
 
     // Jackson(ObjectMapper)이 ZonedDateTime(Java 8 날짜/시간 타입)을 기본적으로 지원하지 않음
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// JMH
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
 }

--- a/BE/src/jmh/java/com/example/BenchmarkApplication.java
+++ b/BE/src/jmh/java/com/example/BenchmarkApplication.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BenchmarkApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BenchmarkApplication.class, args);
+    }
+}
+

--- a/BE/src/jmh/java/com/example/ChatLoadBenchmark.java
+++ b/BE/src/jmh/java/com/example/ChatLoadBenchmark.java
@@ -1,0 +1,69 @@
+package com.example;
+
+import com.example.p24zip.domain.chat.entity.Chat;
+import com.example.p24zip.domain.chat.repository.ChatRepository;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 1)       // 워밍업 1회
+@Measurement(iterations = 5)  // 측정 3회
+@State(Scope.Benchmark)
+public class ChatLoadBenchmark {
+
+    private static ConfigurableApplicationContext context;
+    private final Long movingPlanId = 1L;
+    private final Long messageId = 300L;
+    private final PageRequest pageable = PageRequest.of(0, 10);
+    private ChatRepository chatRepository;
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        if (context == null) {
+            context = SpringApplication.run(BenchmarkApplication.class);
+        }
+        chatRepository = context.getBean(ChatRepository.class);
+        redisTemplate = context.getBean("redisTemplate", RedisTemplate.class);
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        if (context != null) {
+            context.close();
+            context = null;
+        }
+    }
+
+    @Benchmark
+    public List<Object> loadFromRedis() {
+        return redisTemplate.opsForList().range("chat:1", 0, 9);
+    }
+
+    @Benchmark
+    public List<Chat> loadFromMySQL_QueryMethod() {
+        return chatRepository.findByMovingPlan_IdAndIdGreaterThanEqualOrderByIdAsc(
+            movingPlanId, messageId, pageable);
+    }
+
+    @Benchmark
+    public List<Chat> loadFromMySQL_JPQL() {
+        return chatRepository.findChatsBeforeId(movingPlanId, messageId, pageable);
+    }
+}

--- a/BE/src/jmh/java/com/example/ChatLoadBenchmark_function.java
+++ b/BE/src/jmh/java/com/example/ChatLoadBenchmark_function.java
@@ -1,0 +1,86 @@
+package com.example;
+
+import com.example.p24zip.domain.chat.dto.response.ChatsResponseDto;
+import com.example.p24zip.domain.chat.service.ChatService;
+import com.example.p24zip.domain.user.entity.User;
+import com.example.p24zip.domain.user.repository.UserRepository;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+
+@State(Scope.Benchmark)
+@BenchmarkMode({Mode.AverageTime, Mode.Throughput})
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+public class ChatLoadBenchmark_function {
+
+    private static ConfigurableApplicationContext context;
+    private Long movingPlanId = 3L;
+    private ChatService chatService;
+    private UserRepository userRepository;
+    private User user;
+
+    // 상태 유지용 messageId
+    private long messageId = 783L;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        if (context == null) {
+            context = SpringApplication.run(BenchmarkApplication.class);
+        }
+        this.userRepository = context.getBean(UserRepository.class);
+        this.chatService = context.getBean(ChatService.class);
+        this.user = userRepository.findByUsername("test@test.com").get();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        if (context != null) {
+            context.close();
+            context = null;
+        }
+    }
+
+    // 이전 메시지 조회
+    @Benchmark
+    public ChatsResponseDto benchmarkGetPreviousMessages() {
+        return chatService.getPreviousMessages(
+            movingPlanId,
+            user,
+            messageId
+        );
+    }
+
+    // 매 호출 후 messageId 증가
+    @TearDown(Level.Invocation)
+    public void increaseMessageId() {
+        if (messageId < 837L) {
+            messageId += 50;
+            if (messageId > 837L) {
+                messageId = 837L;
+            }
+        }
+    }
+
+    // 다음 메시지 조회
+    @Benchmark
+    public ChatsResponseDto benchmarkGetNextMessages() {
+        return chatService.readChats(
+            movingPlanId,
+            user,
+            50
+        );
+    }
+}

--- a/BE/src/main/java/com/example/p24zip/P24zipApplication.java
+++ b/BE/src/main/java/com/example/p24zip/P24zipApplication.java
@@ -3,8 +3,10 @@ package com.example.p24zip;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @EnableJpaAuditing
+@EnableJpaRepositories
 @SpringBootApplication
 public class P24zipApplication {
 

--- a/BE/src/main/java/com/example/p24zip/domain/chat/repository/ChatRepository.java
+++ b/BE/src/main/java/com/example/p24zip/domain/chat/repository/ChatRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
@@ -16,6 +17,19 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
         @Param("movingPlanId") Long movingPlanId,
         @Param("messageId") Long messageId,
         Pageable pageable);
+
+    // Cursor messageId 기준 이전 메세지들 가져옴
+    @Query("""
+            SELECT c FROM Chat c
+            WHERE c.movingPlan.id = :movingPlanId
+              AND c.id < :messageId
+            ORDER BY c.id DESC
+        """)
+    List<Chat> findChatsBeforeId(
+        @Param("movingPlanId") Long movingPlanId,
+        @Param("messageId") Long messageId,
+        Pageable pageable);
+
 
     // Cursor messageId 기준 이전 메세지들 가져옴
     List<Chat> findByMovingPlan_IdAndIdLessThanOrderByIdDesc(

--- a/BE/src/main/java/com/example/p24zip/domain/chat/repository/ChatRepository.java
+++ b/BE/src/main/java/com/example/p24zip/domain/chat/repository/ChatRepository.java
@@ -18,6 +18,25 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
         @Param("messageId") Long messageId,
         Pageable pageable);
 
+    // Cursor messageId 기준 다음 메세지들 가져옴
+    @Query("""
+            SELECT c FROM Chat c
+            WHERE c.movingPlan.id = :movingPlanId
+              AND c.id >= :messageId
+            ORDER BY c.id ASC
+        """)
+    List<Chat> findChatsAfterId(
+        @Param("movingPlanId") Long movingPlanId,
+        @Param("messageId") Long messageId,
+        Pageable pageable);
+
+
+    // Cursor messageId 기준 이전 메세지들 가져옴
+    List<Chat> findByMovingPlan_IdAndIdLessThanOrderByIdDesc(
+        @Param("movingPlanId") Long movingPlanId,
+        @Param("messageId") Long messageId,
+        Pageable pageable);
+
     // Cursor messageId 기준 이전 메세지들 가져옴
     @Query("""
             SELECT c FROM Chat c
@@ -31,12 +50,6 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
         Pageable pageable);
 
 
-    // Cursor messageId 기준 이전 메세지들 가져옴
-    List<Chat> findByMovingPlan_IdAndIdLessThanOrderByIdDesc(
-        @Param("movingPlanId") Long movingPlanId,
-        @Param("messageId") Long messageId,
-        Pageable pageable);
-
     // messageId 없을 경우 가장 최신 메세지만 가져오기
     List<Chat> findByMovingPlan_IdOrderByIdDesc(
         @Param("movingPlanId") Long movingPlanId,
@@ -44,11 +57,12 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
 
 
     @Modifying
-    void deleteByMovingPlan_Id(@Param("movingPlanId") Long movingPlanId);
+    void deleteByMovingPlan_Id(Long movingPlanId);
 
 
-    Optional<Chat> findById(@Param("messageId") Long messageId);
+    Optional<Chat> findById(Long messageId);
 
 
     List<Chat> findByUser(User user);
+
 }

--- a/BE/src/main/java/com/example/p24zip/domain/chat/service/ChatService.java
+++ b/BE/src/main/java/com/example/p24zip/domain/chat/service/ChatService.java
@@ -158,11 +158,11 @@ public class ChatService {
 
         } else {
             Pageable pageable = PageRequest.of(0, size, Sort.by(Direction.DESC, "id"));
-            chats = chatRepository.findByMovingPlan_IdAndIdGreaterThanEqualOrderByIdAsc(
+            chats = chatRepository.findChatsAfterId(
                 movingPlanId, lastReadMessageId, pageable);
 
             if (chats.size() == 1) {
-                chats = chatRepository.findByMovingPlan_IdAndIdGreaterThanEqualOrderByIdAsc(
+                chats = chatRepository.findChatsAfterId(
                     movingPlanId, lastReadMessageId - size,
                     pageable);
 
@@ -392,7 +392,7 @@ public class ChatService {
         } else {
             Pageable pageable = PageRequest.of(0, 10, Sort.by(Direction.DESC, "id"));
 
-            List<Chat> chats = chatRepository.findByMovingPlan_IdAndIdLessThanOrderByIdDesc(
+            List<Chat> chats = chatRepository.findChatsBeforeId(
                 movingPlanId, messageId, pageable);
 
             // Redis 커서 이하 메시지는 잘라냄 => 사용자가 처음 본 메세지까지만 볼 수 있음


### PR DESCRIPTION
## 📝 변경 사항

- Benchmark test를 하기 위해 build.gradle에 JMH Gradle 플러그인 설정
- test 하기 위해 테스트 코드 작성

## 📸 스크린샷
-  thruput (thrpt) 모드: Throughput → 시간당 처리량
- average time (avgt) 모드: Average Time → 한 번 작업을 수행하는 데 걸린 평균 시간

<img width="1097" height="184" alt="스크린샷 2025-08-13 030102" src="https://github.com/user-attachments/assets/3b75c70d-f981-43ec-aa0b-668474790de8" />
<img width="1146" height="198" alt="스크린샷 2025-08-13 033404" src="https://github.com/user-attachments/assets/8562afa4-a26d-4eb1-acc8-f7f07a9592b9" />
<img width="1354" height="193" alt="스크린샷 2025-08-13 153954" src="https://github.com/user-attachments/assets/2eb7b098-01dd-4776-873a-c35ec03dd656" />
<img width="1248" height="177" alt="스크린샷 2025-08-13 160103" src="https://github.com/user-attachments/assets/59d15946-4bb1-46c6-86fe-c197b3af6e6d" />
<img width="1192" height="170" alt="스크린샷 2025-08-13 165536" src="https://github.com/user-attachments/assets/ab761b3c-e04a-4647-99b2-d174c387b354" />

###  결과
#### SQL
- nextMessage 조회 시 JPQL은 QueryMethod보다 처리량 2.37배, 속도 1.54배 우위
- previousMessage 조회 시 JPQL은 QueryMethod보다 처리량 1.36배, 속도 1.98배 우위

#### function
-  nextMessage 조회 시 JPQL은 QueryMethod보다 처리량 27.27%, 속도 38.44% 상승

-  previousMessage 조회 시 JPQL은 QueryMethod보다 처리량 18.18%, 속도 30.46% 상승

## 📌 참고 사항

- JMH(Java Microbenchmark Harness) 는 JDK17 이상을 요구함