### PR TITLE
[fix] 채팅 서버 시간대 오류 수정을 위한 서버 타임존 설정

### DIFF
--- a/BE/src/main/java/com/example/p24zip/P24zipApplication.java
+++ b/BE/src/main/java/com/example/p24zip/P24zipApplication.java
@@ -1,5 +1,6 @@
 package com.example.p24zip;
 
+import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -11,6 +12,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 public class P24zipApplication {
 
     public static void main(String[] args) {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
         SpringApplication.run(P24zipApplication.class, args);
     }
 


### PR DESCRIPTION
## 📝 변경 사항
- Spring Boot 애플리케이션 시작 시 서버 기본 타임존을 Asia/Seoul로 설정


## 📌 참고 사항
- EC2의 서버 시간은 한국 시간대로 잘 맞춰져 있었는데 서버 시간대가 UTC로 되어 있어 채팅이 저장되는 시간이 9시간 빨랐다.
<img width="221" height="25" alt="스크린샷 2025-08-21 000610" src="https://github.com/user-attachments/assets/74c1f980-518a-466a-bb90-211def94eba4" />
