### PR TITLE
[refactor] FCM서버로 알림 메시지 전송 로직 비동기 처리로 실행 속도 개선

### DIFF
--- a/BE/src/main/java/com/example/p24zip/global/notification/fcm/FcmController.java
+++ b/BE/src/main/java/com/example/p24zip/global/notification/fcm/FcmController.java
@@ -29,4 +29,14 @@ public class FcmController {
         return ApiResponse.ok(CustomCode.FCM_TOKEN_CREATE);
     }
 
+    // fcm 서버로 메세지 요청(부하테스트용)
+    @PostMapping("/sendMessage")
+    public void sendMessage(@RequestBody FcmMessage fcmMessage) throws IOException {
+        fcmService.sendMessageTo(
+            fcmMessage.getMessage().getToken(),
+            fcmMessage.getMessage().getNotification().getTitle(),
+            fcmMessage.getMessage().getNotification().getBody()
+        );
+    }
+
 }

--- a/BE/src/main/java/com/example/p24zip/global/notification/fcm/FcmService.java
+++ b/BE/src/main/java/com/example/p24zip/global/notification/fcm/FcmService.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.Call;
+import okhttp3.Callback;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -94,9 +96,20 @@ public class FcmService {
             .addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // header에 포함
             .addHeader(HttpHeaders.CONTENT_TYPE, "application/json; UTF-8")
             .build();
-        Response response = okHttpClient.newCall(request).execute(); // 요청 보냄
 
-        log.info(response.body().string());
+        // okHttpClient의 비동기 방식
+        okHttpClient.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(Call call, IOException e) {
+                log.error("FCM 전송 실패", e);
+            }
+
+            @Override
+            public void onResponse(Call call, Response response) throws IOException {
+                log.info("FCM 전송 성공: {}", response.body().string());
+            }
+        });
+
     }
 
 


### PR DESCRIPTION
## 📝 변경 사항

- OkHttpClient로 fcm 서버에 알림 메세지 동기로 요청하던 코드 비동기로 요청하도록 수정

## 📸 스크린샷
- 동기 방식으로 부하테스트 해본 결과
<img width="1842" height="623" alt="image" src="https://github.com/user-attachments/assets/df9f1600-3dac-4906-82e8-1b151d8bfbaf" />

- 비동기 방식으로 부하테스트 해본 결과
<img width="1846" height="621" alt="image" src="https://github.com/user-attachments/assets/b3b2d9b9-1183-45e2-87ff-10d5cb3f7fd8" />


## 📌 참고 사항
- 정상 전송
INFO 640 --- [p24zip] [gleapis.com/...] c.e.p.g.notification.fcm.FcmService      : FCM 전송 성공: {
  "name": "projects/project-2f2a4/messages/4e4a967c-1c6e-4d43-aa35-80b63acdf545"
}

- 비정상 전송
INFO 640 --- [p24zip] [gleapis.com/...] c.e.p.g.notification.fcm.FcmService : FCM 전송 성공: { "error": { "code": 429, "message": "resource exhausted: 429 , token:https://wns2-pn1p.notify.windows.com/w/?token=BQYAAACnL7yqU9je7e6mOxx26o1wW%2fPaXCQTES3s32HH%2bqSNvkfh6lalIElnyIFxXhLr1F1foWhWv9qelzdC9nWDPB7Kq5MvAUSxuOlme6KOf8kTXSgld494CjiE4%2fEdjByTC7TTmdj9U0ZZ%2bBvC%2bX9u9JlwFZMJawmwo5JoCcZxlrOZ%2bnOjYFRghdxlGgjrZiUVHOdyNE2aexlfE%2btZB29vZz6eeje58bL%2fGHl6uqNAU6V4LWASDuuJJXEV3%2fcezNzc0WV9d2kPv3J0UlG3d9fok7%2blTZcpj4G%2fNYzMYhAaLNkJKQVrs9E5zwcoWo25wVw37GY%3d", "status": "RESOURCE_EXHAUSTED", "details": [ { "@type": "type.googleapis.com/google.firebase.fcm.v1.FcmError", "errorCode": "QUOTA_EXCEEDED" } ] } }
           
429 RESOURCE_EXHAUSTED
QUOTA_EXCEEDED           
FCM 서버에서 허용하는 요청 쿼터(할당량) 또는 초당 요청 수 제한을 초과했을 때 발생
짧은 시간 안에 대량의 요청 → FCM 서버에서 스팸/과도한 요청으로 판단 → 제한 걸림
           
알림이 가다가 일부 요청 수가 초과되면 알림이 막힘
